### PR TITLE
Don't make paths absolute

### DIFF
--- a/tasks/grunt-contrib-testem.coffee
+++ b/tasks/grunt-contrib-testem.coffee
@@ -126,7 +126,7 @@ task = (grunt, mode) ->
     else
       cwd = environment.paths[0]
       grunt.file.expand({cwd: cwd}, @config("src") || []).forEach (match) ->
-        files[match] = Path.join(cwd, match)
+        files[match] = match
 
   # Options defaults
   options['launch_in_ci']  = [grunt.option('launch')] if grunt.option('launch')


### PR DESCRIPTION
Fireworm (the file watcher that testem uses) expects relative paths, which is why auto-restarting isn't working (see #13). I've already tested this patch in our repository and restarting now works as expected. Not sure how this affects all your mincer stuff, but frankly that seems peripheral to this issue. If the filewatching test reruns don't work (they don't), then that's the most critical problem.